### PR TITLE
fix support bitbucket

### DIFF
--- a/pegmatite/content-script.js
+++ b/pegmatite/content-script.js
@@ -113,6 +113,12 @@ var siteProfiles = {
 		"selector": "div.codehilite.language-plantuml > pre",
 		"extract": function (elem) {
 			return elem.innerText.trim();
+		},
+		replace: function(elem) {
+			return elem;
+		},
+		compress: function(elem) {
+			return compress(elem.innerText.trim());
 		}
 	},
 	"backlog.jp": {


### PR DESCRIPTION
I find a bug in bitbucket linkage support function. I fix it.

before
<img width="1552" alt="スクリーンショット 2019-04-14 19 52 20" src="https://user-images.githubusercontent.com/150444/56092125-da5aef80-5ef2-11e9-8b78-b0714dbd5062.png">

after
<img width="1552" alt="スクリーンショット 2019-04-14 19 55 51" src="https://user-images.githubusercontent.com/150444/56092129-e0e96700-5ef2-11e9-8f6d-6104e2669122.png">
